### PR TITLE
Make pfp synchronous on home and profile page (issue 77)

### DIFF
--- a/frontend/src/components/feed/Feed.js
+++ b/frontend/src/components/feed/Feed.js
@@ -171,6 +171,8 @@ function Feed({ profileData, setProfileData, user }) {
                             key={post.id}
                             author={post.author}
                             text={post.text}
+                            pfp={pfpUrl}
+                            setPfp={setPfpUrl}
                             imgUrl={post.imgUrl}
                             created={post.created}
                             refTx={post.refTx}

--- a/frontend/src/components/posts/Post.js
+++ b/frontend/src/components/posts/Post.js
@@ -34,9 +34,10 @@ function Post(props) {
         ERC721Transfer: "erc721transfer",
     }
 
+    const { pfp, setPfp } = props
+
     // state
     const refTx = props.refTx;
-    const [pfpUrl, setPfpUrl] = useState(props.pfp)
     const [erc20Transfers, setErc20Transfers] = useState([]);
     const [erc721Transfers, setErc721Transfers] = useState([]);
     const [txType, setTxType] = useState(null);
@@ -100,9 +101,9 @@ function Post(props) {
      * if the user has not uploaded a profile pic.
      */
     useEffect(() => {
-        if (!pfpUrl) {
+        if (!pfp) {
             if (!ensAvatar.isLoading && ensAvatar.data !== null) {
-                setPfpUrl(ensAvatar.data);
+                setPfp(ensAvatar.data);
             }
         }
     }, [ensAvatar])
@@ -126,7 +127,7 @@ function Post(props) {
                                         <Pfp
                                             height="100px"
                                             width="100px"
-                                            imgUrl={pfpUrl}
+                                            imgUrl={pfp}
                                             address={props.author}
                                             ensName={ensName}
                                             fontSize="1rem"

--- a/frontend/src/pages/Home.js
+++ b/frontend/src/pages/Home.js
@@ -14,11 +14,9 @@ function Home() {
     // state
     useEffect(() => {
       setProfileData(user)
-      console.log('setProfileData to user')
     }, [user])
 
     useEffect(() => {
-      console.log('profile data recognized')
       setLoading(false)
         console.log('profile data: ', profileData)
     }, [profileData])


### PR DESCRIPTION
**Current Behavior**
Post PFP on user's profile sometimes displays Blockie. Other times it will display the PFP associated to the profile.

**Expected Behavior**
User's profile picture should remain constant on profile header and posts.

**Fix:**
removed pfpUrl state on child component.
passed down pfp from home and profile to feed/post component